### PR TITLE
Fixed detecting if response is json

### DIFF
--- a/APIBlueprintGenerator.coffee
+++ b/APIBlueprintGenerator.coffee
@@ -22,7 +22,8 @@ APIBlueprintGenerator = ->
     is_json = false
     for key, value of exchange.responseHeaders
       if key in ['Content-Type', 'Connection', 'Date', 'Via', 'Server', 'Content-Length']
-        is_json = (key == 'Content-Type' && value.search(/(json)/i) > -1)
+        if key == 'Content-Type'
+          is_json = value.search(/(json)/i) > -1
         continue
 
       headers.push({ key: key, value: value })


### PR DESCRIPTION
The is_json check looked at each key and evaluated if the current key was `Content-Type` and had `json` in it. However, since it was looping over all the keys at the same time then `is_json` would get overwritten since at some point there would be another header which wasn't `Content-Type` and the check would fail.